### PR TITLE
style: github language attribute ignore Makefile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
-.Makefile linguist-language=cpp
+code/threads/Makefile linguist-language=cpp
+code/userprog/Makefile linguist-language=cpp
+code/Makefile linguist-language=cpp
+code/test/Makefile linguist-language=cpp
+code/filesys/Makefile linguist-language=cpp
+code/network/Makefile linguist-language=cpp
+code/bin/Makefile linguist-language=cpp
+c++example/Makefile linguist-language=cpp


### PR DESCRIPTION
Due to a large amount of expanded file path code in Makefile all over this project, it will make GitHub think that this is a Makefile-based project.
I change the GitHub attribute file and now it shows that this is a C++-based project.