### PR TITLE
style: let Github ignore Makefile during the showing of  Languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-.Makefile linguist-language=cpp
+Makefile linguist-detectable=false


### PR DESCRIPTION
Due to a large amount of expanded file path code in Makefile all over this project, it will make GitHub think that this is a Makefile-based project.
I change the GitHub attribute file and now it shows that this is a C++-based project.